### PR TITLE
modern import path, fix formatting

### DIFF
--- a/highcharts.go
+++ b/highcharts.go
@@ -1,11 +1,12 @@
 package highcharts
 
 import (
-    "net/http"
-    "html/template"
-    "log"
-    "encoding/json"
-    "fmt"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+
 	"golang.org/x/net/websocket"
 )
 
@@ -16,17 +17,17 @@ var port = ":8080"
 // NewChart creates a new highchart based on options argument at url
 // View at http://localhost:8080/url/
 // To change port see SetPort
-func NewChart(url string, options interface{}){
-    http.HandleFunc(url, indexHandler)
-    http.HandleFunc(url + "data/", func(w http.ResponseWriter, r *http.Request) {
-        opts, err := json.Marshal(options)
-        if err != nil{
-            log.Fatal(err)
-        }
-        fmt.Fprintf(w, string(opts))
-    })
+func NewChart(url string, options interface{}) {
+	http.HandleFunc(url, indexHandler)
+	http.HandleFunc(url+"data/", func(w http.ResponseWriter, r *http.Request) {
+		opts, err := json.Marshal(options)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Fprintf(w, string(opts))
+	})
 
-    eventualServerStart()
+	eventualServerStart()
 }
 
 // NewDynamicChart creates a new highchart based on options argument at url
@@ -35,51 +36,54 @@ func NewChart(url string, options interface{}){
 // Only support one channel on one graph for now.
 // View at http://localhost:8080/url/
 // To change port see SetPort
-func NewDynamicChart(url string, options interface{}, channel chan interface{}){
-    http.HandleFunc(url, indexHandler)
-    http.HandleFunc(url + "data/", func(w http.ResponseWriter, r *http.Request) {
-        opts, err := json.Marshal(options)
-        if err != nil{
-            log.Fatal(err)
-        }
-        fmt.Fprintf(w, string(opts))
-    })
-    http.Handle(url + "streaming/", websocket.Handler(func (c *websocket.Conn){
-        for ;; {
-            data := <-channel
-            fmt.Fprint(c, data)
-        }
-    }))
-    eventualServerStart()
+func NewDynamicChart(url string, options interface{}, channel chan interface{}) {
+	http.HandleFunc(url, indexHandler)
+	http.HandleFunc(url+"data/", func(w http.ResponseWriter, r *http.Request) {
+		opts, err := json.Marshal(options)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Fprintf(w, string(opts))
+	})
+	http.Handle(url+"streaming/", websocket.Handler(func(c *websocket.Conn) {
+		for {
+			data := <-channel
+			fmt.Fprint(c, data)
+		}
+	}))
+	eventualServerStart()
 
 }
 
 // SetPort sets the port for the server to see the graphs
 // Is in the same format as ListenAndServe, ":8080"
-func SetPort(serverPort string){
-    port = serverPort
-    started = false
+func SetPort(serverPort string) {
+	port = serverPort
+	started = false
 }
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
-    t, err := template.ParseFiles("tmpl/base.html")
-    if err != nil{
-        log.Fatal(err)
-    }
-    t.Execute(w, nil)
+	t, err := template.ParseFiles("tmpl/base.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = t.Execute(w, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
-func eventualServerStart(){
-    if !started{
-        if !static {
-            http.HandleFunc("/static/", func(w http.ResponseWriter, r *http.Request) {
-                http.ServeFile(w, r, r.URL.Path[1:])
-            })
-            static = true
-        }
-        go func(){
-            started = true
-            log.Fatal(http.ListenAndServe(port, nil))
-        }()
-    }
+func eventualServerStart() {
+	if !started {
+		if !static {
+			http.HandleFunc("/static/", func(w http.ResponseWriter, r *http.Request) {
+				http.ServeFile(w, r, r.URL.Path[1:])
+			})
+			static = true
+		}
+		go func() {
+			started = true
+			log.Fatal(http.ListenAndServe(port, nil))
+		}()
+	}
 }

--- a/highcharts.go
+++ b/highcharts.go
@@ -6,14 +6,14 @@ import (
     "log"
     "encoding/json"
     "fmt"
-    "code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 var started = false
 var static = false
 var port = ":8080"
 
-// Creates a new highchart based on options argument at url
+// NewChart creates a new highchart based on options argument at url
 // View at http://localhost:8080/url/
 // To change port see SetPort
 func NewChart(url string, options interface{}){
@@ -29,7 +29,7 @@ func NewChart(url string, options interface{}){
     eventualServerStart()
 }
 
-// Creates a new highchart based on options argument at url
+// NewDynamicChart creates a new highchart based on options argument at url
 // Whenever you add data to your channel it will be sent to
 // your graph via websocket.
 // Only support one channel on one graph for now.
@@ -54,15 +54,14 @@ func NewDynamicChart(url string, options interface{}, channel chan interface{}){
 
 }
 
-// Sets the port for the server to see the graphs
+// SetPort sets the port for the server to see the graphs
 // Is in the same format as ListenAndServe, ":8080"
-func SetPort(server_port string){
-    port = server_port
+func SetPort(serverPort string){
+    port = serverPort
     started = false
 }
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
-    t := template.New("base")
     t, err := template.ParseFiles("tmpl/base.html")
     if err != nil{
         log.Fatal(err)

--- a/highcharts_test.go
+++ b/highcharts_test.go
@@ -1,145 +1,145 @@
 package highcharts
 
 import (
-    "testing"
-    "net/http"
-    "io/ioutil"
-    "time"
-    "strconv"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
 	"golang.org/x/net/websocket"
 )
 
-func TestNewChart(t *testing.T){
-    options := map[string]interface{}{
-        "series":  []interface{}{
-            map[string]interface{}{
-                "name": "toto",
-                "data": []int{1, 2, 3},
-            },
-        },
-        "chart": map[string]interface{}{
-            "type": "line",
-        },
-    }
-    NewChart("/chart/", options)
+func TestNewChart(t *testing.T) {
+	options := map[string]interface{}{
+		"series": []interface{}{
+			map[string]interface{}{
+				"name": "toto",
+				"data": []int{1, 2, 3},
+			},
+		},
+		"chart": map[string]interface{}{
+			"type": "line",
+		},
+	}
+	NewChart("/chart/", options)
 
-    resp, err := http.Get("http://localhost:8080/chart/")
-    if err != nil{
-        t.Errorf("Error while loading chart page, %v", err)
-    }
-    if resp.StatusCode != 200{
-        t.Errorf("Error while reading chart page, %v", err)
-    }
-    defer resp.Body.Close()
-    _, err = ioutil.ReadAll(resp.Body)
-    if err != nil{
-        t.Errorf("Error while reading chart page, %v", err)
-    }
-    // fmt.Println(string(body))
+	resp, err := http.Get("http://localhost:8080/chart/")
+	if err != nil {
+		t.Errorf("Error while loading chart page, %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Error while reading chart page, %v", err)
+	}
+	defer resp.Body.Close()
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("Error while reading chart page, %v", err)
+	}
+	// fmt.Println(string(body))
 
-    resp, err = http.Get("http://localhost:8080/chart/data/")
-    if err != nil{
-        t.Errorf("Error while loading chart data page, %v", err)
-    }
-    defer resp.Body.Close()
-    body, err := ioutil.ReadAll(resp.Body)
-    if err != nil{
-        t.Errorf("Error while reading chart data page, %v", err)
-    }
-    expMsg := "{\"chart\":{\"type\":\"line\"},\"series\":[{\"data\":[1,2,3],\"name\":\"toto\"}]}"
-    strMsg := string(body)
-    if strMsg != expMsg {
-        t.Errorf("Did not receive the correct JSON expected %v got %v", expMsg, strMsg)
-    }
+	resp, err = http.Get("http://localhost:8080/chart/data/")
+	if err != nil {
+		t.Errorf("Error while loading chart data page, %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("Error while reading chart data page, %v", err)
+	}
+	expMsg := "{\"chart\":{\"type\":\"line\"},\"series\":[{\"data\":[1,2,3],\"name\":\"toto\"}]}"
+	strMsg := string(body)
+	if strMsg != expMsg {
+		t.Errorf("Did not receive the correct JSON expected %v got %v", expMsg, strMsg)
+	}
 
+	_, err = http.Get("http://localhost:8080/static/js/highcharts.js")
+	if err != nil {
+		t.Errorf("Error while reading static page, %v", err)
+	}
 
-    _, err = http.Get("http://localhost:8080/static/js/highcharts.js")
-    if err != nil{
-        t.Errorf("Error while reading static page, %v", err)
-    }
-
-    _, err = http.Get("http://localhost:8080/static/js/load.js")
-    if err != nil{
-        t.Errorf("Error while reading static page, %v", err)
-    }
+	_, err = http.Get("http://localhost:8080/static/js/load.js")
+	if err != nil {
+		t.Errorf("Error while reading static page, %v", err)
+	}
 }
 
-func TestDynamicChart(t *testing.T){
-    data := make(chan interface{})
-    options := map[string]interface{}{
-        "series":  []interface{}{
-            map[string]interface{}{
-                "name": "toto",
-                "data": []int{},
-            },
-        },
-        "chart": map[string]interface{}{
-            "type": "line",
-        },
-    }
-    NewDynamicChart("/dynamic/", options, data)
-    go func(){
-        for i := 0; i < 10; i++{
-            data<-i
-            // Uncomment to test in browser
-            // time.Sleep(1e9)
-            time.Sleep(time.Second)
-        }
-    }()
-    resp, err := http.Get("http://localhost:8080/dynamic/")
-    if err != nil{
-        t.Errorf("Error while loading dynamic chart data page, %v", err)
-    }
-    defer resp.Body.Close()
-    _, err = ioutil.ReadAll(resp.Body)
-    if err != nil{
-        t.Errorf("Error while reading dynamic data page, %v", err)
-    }
+func TestDynamicChart(t *testing.T) {
+	data := make(chan interface{})
+	options := map[string]interface{}{
+		"series": []interface{}{
+			map[string]interface{}{
+				"name": "toto",
+				"data": []int{},
+			},
+		},
+		"chart": map[string]interface{}{
+			"type": "line",
+		},
+	}
+	NewDynamicChart("/dynamic/", options, data)
+	go func() {
+		for i := 0; i < 10; i++ {
+			data <- i
+			// Uncomment to test in browser
+			// time.Sleep(1e9)
+			time.Sleep(time.Second)
+		}
+	}()
+	resp, err := http.Get("http://localhost:8080/dynamic/")
+	if err != nil {
+		t.Errorf("Error while loading dynamic chart data page, %v", err)
+	}
+	defer resp.Body.Close()
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("Error while reading dynamic data page, %v", err)
+	}
 
-    origin := "http://localhost/"
-    url := "ws://localhost:8080/dynamic/streaming/"
-    ws, err := websocket.Dial(url, "", origin)
-    if err != nil {
-        t.Errorf("Cannot open websocket, %v", err)
-    }
-    var msg = make([]byte, 512)
-    var n int
-    for i := 0; i< 10; i++{
-        n, err = ws.Read(msg)
-        if err != nil {
-            t.Errorf("Cannot receive on websocket, %v", err)
-        }
-        strMsg := string(msg[:n])
-        expMsg := strconv.Itoa(i)
-        if strMsg != expMsg {
-            t.Errorf("Did not receive the correct message on websocket expected %v got %v", expMsg, strMsg)
-        }
-    }
+	origin := "http://localhost/"
+	url := "ws://localhost:8080/dynamic/streaming/"
+	ws, err := websocket.Dial(url, "", origin)
+	if err != nil {
+		t.Errorf("Cannot open websocket, %v", err)
+	}
+	var msg = make([]byte, 512)
+	var n int
+	for i := 0; i < 10; i++ {
+		n, err = ws.Read(msg)
+		if err != nil {
+			t.Errorf("Cannot receive on websocket, %v", err)
+		}
+		strMsg := string(msg[:n])
+		expMsg := strconv.Itoa(i)
+		if strMsg != expMsg {
+			t.Errorf("Did not receive the correct message on websocket expected %v got %v", expMsg, strMsg)
+		}
+	}
 
-    // Uncomment to test in browser
-    // time.Sleep(1e11)
+	// Uncomment to test in browser
+	// time.Sleep(1e11)
 }
 
-func TestNewPort(t *testing.T){
-    options := map[string]interface{}{
-        "series":  []interface{}{
-            map[string]interface{}{
-                "name": "toto",
-                "data": []int{1, 2, 3},
-            },
-        },
-        "chart": map[string]interface{}{
-            "type": "line",
-        },
-    }
-    SetPort(":8081")
-    NewChart("/newport/", options)
+func TestNewPort(t *testing.T) {
+	options := map[string]interface{}{
+		"series": []interface{}{
+			map[string]interface{}{
+				"name": "toto",
+				"data": []int{1, 2, 3},
+			},
+		},
+		"chart": map[string]interface{}{
+			"type": "line",
+		},
+	}
+	SetPort(":8081")
+	NewChart("/newport/", options)
 
-    resp, err := http.Get("http://localhost:8081/newport/")
-    if err != nil{
-        t.Errorf("Error while loading chart page, %v", err)
-    }
-    if resp.StatusCode != 200{
-        t.Errorf("Error while reading chart page, %v", err)
-    }
+	resp, err := http.Get("http://localhost:8081/newport/")
+	if err != nil {
+		t.Errorf("Error while loading chart page, %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Error while reading chart page, %v", err)
+	}
 }

--- a/highcharts_test.go
+++ b/highcharts_test.go
@@ -5,8 +5,8 @@ import (
     "net/http"
     "io/ioutil"
     "time"
-    "code.google.com/p/go.net/websocket"
     "strconv"
+	"golang.org/x/net/websocket"
 )
 
 func TestNewChart(t *testing.T){
@@ -25,42 +25,42 @@ func TestNewChart(t *testing.T){
 
     resp, err := http.Get("http://localhost:8080/chart/")
     if err != nil{
-        t.Errorf("Error while loading chart page", err)
+        t.Errorf("Error while loading chart page, %v", err)
     }
     if resp.StatusCode != 200{
-        t.Errorf("Error while reading chart page", err)
+        t.Errorf("Error while reading chart page, %v", err)
     }
     defer resp.Body.Close()
-    body, err := ioutil.ReadAll(resp.Body)
+    _, err = ioutil.ReadAll(resp.Body)
     if err != nil{
-        t.Errorf("Error while reading chart page", err)
+        t.Errorf("Error while reading chart page, %v", err)
     }
     // fmt.Println(string(body))
 
     resp, err = http.Get("http://localhost:8080/chart/data/")
     if err != nil{
-        t.Errorf("Error while loading chart data page", err)
+        t.Errorf("Error while loading chart data page, %v", err)
     }
     defer resp.Body.Close()
-    body, err = ioutil.ReadAll(resp.Body)
+    body, err := ioutil.ReadAll(resp.Body)
     if err != nil{
-        t.Errorf("Error while reading chart data page", err)
+        t.Errorf("Error while reading chart data page, %v", err)
     }
-    expmsg := "{\"chart\":{\"type\":\"line\"},\"series\":[{\"data\":[1,2,3],\"name\":\"toto\"}]}"
-    strmsg := string(body)
-    if strmsg != expmsg{
-        t.Errorf("Did not receive the correct JSON exepected ", expmsg, " got ", strmsg)
-    }
-
-
-    resp, err = http.Get("http://localhost:8080/static/js/highcharts.js")
-    if err != nil{
-        t.Errorf("Error while reading static page", err)
+    expMsg := "{\"chart\":{\"type\":\"line\"},\"series\":[{\"data\":[1,2,3],\"name\":\"toto\"}]}"
+    strMsg := string(body)
+    if strMsg != expMsg {
+        t.Errorf("Did not receive the correct JSON expected %v got %v", expMsg, strMsg)
     }
 
-    resp, err = http.Get("http://localhost:8080/static/js/load.js")
+
+    _, err = http.Get("http://localhost:8080/static/js/highcharts.js")
     if err != nil{
-        t.Errorf("Error while reading static page", err)
+        t.Errorf("Error while reading static page, %v", err)
+    }
+
+    _, err = http.Get("http://localhost:8080/static/js/load.js")
+    if err != nil{
+        t.Errorf("Error while reading static page, %v", err)
     }
 }
 
@@ -83,36 +83,36 @@ func TestDynamicChart(t *testing.T){
             data<-i
             // Uncomment to test in browser
             // time.Sleep(1e9)
-            time.Sleep(1)
+            time.Sleep(time.Second)
         }
     }()
     resp, err := http.Get("http://localhost:8080/dynamic/")
     if err != nil{
-        t.Errorf("Error while loading dynamic chart data page", err)
+        t.Errorf("Error while loading dynamic chart data page, %v", err)
     }
     defer resp.Body.Close()
     _, err = ioutil.ReadAll(resp.Body)
     if err != nil{
-        t.Errorf("Error while reading dynamic data page", err)
+        t.Errorf("Error while reading dynamic data page, %v", err)
     }
 
     origin := "http://localhost/"
     url := "ws://localhost:8080/dynamic/streaming/"
     ws, err := websocket.Dial(url, "", origin)
     if err != nil {
-        t.Errorf("Cannot open websocket", err)
+        t.Errorf("Cannot open websocket, %v", err)
     }
     var msg = make([]byte, 512)
     var n int
     for i := 0; i< 10; i++{
         n, err = ws.Read(msg)
         if err != nil {
-            t.Errorf("Cannot receive on websocket", err)
+            t.Errorf("Cannot receive on websocket, %v", err)
         }
-        strmsg := string(msg[:n])
-        expmsg := strconv.Itoa(i)
-        if strmsg != expmsg {
-            t.Errorf("Did not receive the correct message on websocket exepected ", expmsg, " got ", strmsg)
+        strMsg := string(msg[:n])
+        expMsg := strconv.Itoa(i)
+        if strMsg != expMsg {
+            t.Errorf("Did not receive the correct message on websocket expected %v got %v", expMsg, strMsg)
         }
     }
 
@@ -137,9 +137,9 @@ func TestNewPort(t *testing.T){
 
     resp, err := http.Get("http://localhost:8081/newport/")
     if err != nil{
-        t.Errorf("Error while loading chart page", err)
+        t.Errorf("Error while loading chart page, %v", err)
     }
     if resp.StatusCode != 200{
-        t.Errorf("Error while reading chart page", err)
+        t.Errorf("Error while reading chart page, %v", err)
     }
 }


### PR DESCRIPTION
Hi!

Thanks for the great example, I found it to be very useful. Here is my humble contribution so it could be run without import adjustments, also I've fixed gometalinter.v2 errors which prevent this code to be used as-is somewhere where gometalinter is a must.